### PR TITLE
feat(cmcd): custom events , custom keys and ec

### DIFF
--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -5,6 +5,7 @@
 ```ts
 
 import type { CmcdEventReportConfig } from '@svta/cml-cmcd';
+import { CmcdEventType } from '@svta/cml-cmcd';
 import type { CmcdKey } from '@svta/cml-cmcd';
 import type { CmcdVersion } from '@svta/cml-cmcd';
 import { EventEmitter } from 'eventemitter3';
@@ -1006,6 +1007,16 @@ export class CMCDController implements ComponentAPI {
     constructor(hls: Hls);
     // (undocumented)
     destroy(): void;
+    // (undocumented)
+    getCustomData(): CmcdCustomDataInput | undefined;
+    // Warning: (ae-forgotten-export) The symbol "CmcdValue" needs to be exported by the entry point hls.d.ts
+    //
+    // (undocumented)
+    recordEvent(eventType: CmcdEventType | string, data?: Record<string, CmcdValue>): void;
+    // Warning: (ae-forgotten-export) The symbol "CmcdCustomDataInput" needs to be exported by the entry point hls.d.ts
+    //
+    // (undocumented)
+    setCustomData(data: CmcdCustomDataInput): void;
 }
 
 // Warning: (ae-missing-release-tag) "CMCDControllerConfig" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -1028,6 +1039,7 @@ export type CMCDControllerConfig = {
     }) => Promise<{
         status: number;
     }>;
+    customData?: Record<string, CmcdValue> | (() => Record<string, CmcdValue>);
 };
 
 // Warning: (ae-missing-release-tag) "CodecsParsed" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -2214,6 +2226,9 @@ class Hls implements HlsEventEmitter {
     get capLevelToPlayerSize(): boolean;
     // Warning: (ae-setter-with-docs) The doc comment for the property "capLevelToPlayerSize" must appear on the getter, not the setter.
     set capLevelToPlayerSize(shouldStartCapping: boolean);
+    get cmcdCustomData(): Record<string, CmcdValue> | (() => Record<string, CmcdValue>) | undefined;
+    set cmcdCustomData(data: Record<string, CmcdValue> | (() => Record<string, CmcdValue>));
+    cmcdRecordEvent(eventType: string, data?: Record<string, CmcdValue>): void;
     readonly config: HlsConfig;
     createIFramePlayer(configOverride?: Partial<HlsConfig>): HlsIFramesOnly | null;
     createImageIFramePlayer(configOverride?: Partial<HlsConfig>): HlsImageIFramesOnly | null;

--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -4,6 +4,7 @@
 
 ```ts
 
+import type { Cmcd } from '@svta/cml-cmcd';
 import type { CmcdEventReportConfig } from '@svta/cml-cmcd';
 import { CmcdEventType } from '@svta/cml-cmcd';
 import type { CmcdKey } from '@svta/cml-cmcd';
@@ -1008,11 +1009,9 @@ export class CMCDController implements ComponentAPI {
     // (undocumented)
     destroy(): void;
     // (undocumented)
-    getCustomData(): CmcdCustomDataInput | undefined;
+    recordEvent(eventType: CmcdEventType | string, data?: Cmcd): void;
     // (undocumented)
-    recordEvent(eventType: CmcdEventType | string, data?: Record<string, CmcdValue>): void;
-    // (undocumented)
-    setCustomData(data: CmcdCustomDataInput): void;
+    update(data: Cmcd): void;
 }
 
 // Warning: (ae-missing-release-tag) "CMCDControllerConfig" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -1035,18 +1034,7 @@ export type CMCDControllerConfig = {
     }) => Promise<{
         status: number;
     }>;
-    customData?: Record<string, CmcdValue> | (() => Record<string, CmcdValue>);
 };
-
-// Warning: (ae-missing-release-tag) "CmcdCustomDataInput" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
-export type CmcdCustomDataInput = Record<string, CmcdValue> | (() => Record<string, CmcdValue>);
-
-// Warning: (ae-missing-release-tag) "CmcdValue" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
-export type CmcdValue = string | number | boolean | null;
 
 // Warning: (ae-missing-release-tag) "CodecsParsed" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -2232,9 +2220,8 @@ class Hls implements HlsEventEmitter {
     get capLevelToPlayerSize(): boolean;
     // Warning: (ae-setter-with-docs) The doc comment for the property "capLevelToPlayerSize" must appear on the getter, not the setter.
     set capLevelToPlayerSize(shouldStartCapping: boolean);
-    get cmcdCustomData(): Record<string, CmcdValue> | (() => Record<string, CmcdValue>) | undefined;
-    set cmcdCustomData(data: Record<string, CmcdValue> | (() => Record<string, CmcdValue>));
-    cmcdRecordEvent(eventType: string, data?: Record<string, CmcdValue>): void;
+    // (undocumented)
+    cmcdController?: CMCDController;
     readonly config: HlsConfig;
     createIFramePlayer(configOverride?: Partial<HlsConfig>): HlsIFramesOnly | null;
     createImageIFramePlayer(configOverride?: Partial<HlsConfig>): HlsImageIFramesOnly | null;

--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -1009,12 +1009,8 @@ export class CMCDController implements ComponentAPI {
     destroy(): void;
     // (undocumented)
     getCustomData(): CmcdCustomDataInput | undefined;
-    // Warning: (ae-forgotten-export) The symbol "CmcdValue" needs to be exported by the entry point hls.d.ts
-    //
     // (undocumented)
     recordEvent(eventType: CmcdEventType | string, data?: Record<string, CmcdValue>): void;
-    // Warning: (ae-forgotten-export) The symbol "CmcdCustomDataInput" needs to be exported by the entry point hls.d.ts
-    //
     // (undocumented)
     setCustomData(data: CmcdCustomDataInput): void;
 }
@@ -1041,6 +1037,16 @@ export type CMCDControllerConfig = {
     }>;
     customData?: Record<string, CmcdValue> | (() => Record<string, CmcdValue>);
 };
+
+// Warning: (ae-missing-release-tag) "CmcdCustomDataInput" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type CmcdCustomDataInput = Record<string, CmcdValue> | (() => Record<string, CmcdValue>);
+
+// Warning: (ae-missing-release-tag) "CmcdValue" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type CmcdValue = string | number | boolean | null;
 
 // Warning: (ae-missing-release-tag) "CodecsParsed" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //

--- a/docs/API.md
+++ b/docs/API.md
@@ -142,8 +142,7 @@ See [API Reference](https://hlsjs-dev.video-dev.org/api-docs/) for a complete li
   - [`drmSystemOptions`](#drmsystemoptions)
   - [`requestMediaKeySystemAccessFunc`](#requestmediakeysystemaccessfunc)
   - [`cmcd`](#cmcd)
-    - [`cmcdCustomData` — runtime getter/setter](#cmcdcustomdata--runtime-gettersetter)
-    - [`cmcdRecordEvent(eventType, data?)` — fire a CMCD event report](#cmcdrecordeventeventtype-data--fire-a-cmcd-event-report)
+    - [`cmcdController.update / cmcdController.recordEvent` — runtime CMCD API](#cmcdcontrollerupdate--cmcdcontrollerrecordevent--runtime-cmcd-api)
   - [`enableInterstitialPlayback`](#enableinterstitialplayback)
   - [`interstitialAppendInPlace`](#interstitialappendinplace)
   - [`interstitialLiveLookAhead`](#interstitiallivelookahead)
@@ -1906,54 +1905,27 @@ data will be passed on all media requests (manifests, playlists, a/v segments, t
   - `batchSize`: The number of events to batch before sending a report. Defaults to `1` (send each event immediately).
   - `includeKeys`: An optional array of CMCD keys that overrides the top-level `includeKeys` for this target.
 - `loader`: An optional async function `(request) => Promise<{ status }>` used to deliver CMCD v2 event reports. When omitted, event reports are delivered via `fetch` (honoring the Hls `xhrSetup`/`fetchSetup` hooks). Only used when `eventTargets` is configured.
-- `customData`: An optional set of application-defined key-value pairs to include in every CMCD request report. Accepts either a static object or a callback function:
-  - **Static object** — `Record<string, string | number | boolean | null>`. The values are persisted and included unchanged in every request.
-  - **Callback function** — `() => Record<string, string | number | boolean | null>`. Invoked on every request, so values are resolved at the exact moment of each request. Useful for dynamic state. The function must be synchronous and lightweight — it runs in the hot path of every segment request.
-  - Keys must follow the CMCD custom-key convention: reverse-DNS notation with a hyphen separator, e.g. `com.example-myKey`. See the [SVTA custom keys registry](https://github.com/streaming-video-technology-alliance/common-media-client-data-custom-keys).
-  - Custom keys are valid in both CMCD v1 and v2.
-  - Can be updated at runtime via the `cmcdCustomData` setter on the `Hls` instance.
 
-#### `cmcdCustomData` — runtime getter/setter
+#### `cmcdController.update / cmcdController.recordEvent` — runtime CMCD API
+
+`hls.cmcdController` exposes the `CMCDController` instance when CMCD is configured. Use its `update()` and `recordEvent()` methods to inject custom data or fire event reports at runtime.
 
 ```js
-// Read the current value
-const data = hls.cmcdCustomData;
-
-// Set a static object (replaces previous value)
-hls.cmcdCustomData = {
-  'com.mycompany-playerVersion': '3.2.1',
-  'com.mycompany-experimentGroup': 'A',
-};
-
-// Set a callback for dynamic values resolved on every request
-hls.cmcdCustomData = () => ({
-  'com.mycompany-bufferHealth': hls.mainForwardBufferInfo?.len ?? 0,
+// Persist custom keys in every subsequent request report
+hls.cmcdController?.update({
   'com.mycompany-adBreakActive': adManager.isInAdBreak(),
 });
-```
 
-#### `cmcdRecordEvent(eventType, data?)` — fire a CMCD event report
-
-Fires a CMCD event report via the configured `CmcdReporter`. Requires `cmcd.eventTargets` to include a target whose `events` array contains the desired event type; otherwise the CML silently drops the event.
-
-```js
-const hls = new Hls({
-  cmcd: {
-    version: 2,
-    eventTargets: [
-      {
-        url: 'https://analytics.example.com/cmcd',
-        events: ['ce'], // 'ce' = CmcdEventType.CUSTOM_EVENT
-        includeKeys: ['sid', 'cid', 'cen'],
-      },
-    ],
-  },
+// Fire a CMCD event report (requires cmcd.eventTargets with matching events)
+hls.cmcdController?.recordEvent('ce', {
+  cen: 'chapter-change',
+  'com.myco-chapterid': '3',
 });
-
-hls.cmcdRecordEvent('ce', { cen: 'chapter-change', 'com.myco-chapterid': '3' });
 ```
 
-Custom events are only meaningful with `version: 2`. A warning is logged if called with `version: 1`.
+Custom keys must follow the reverse-DNS convention (e.g. `com.example-myKey`). See the [SVTA custom keys registry](https://github.com/streaming-video-technology-alliance/common-media-client-data-custom-keys). To include custom keys in event payloads, add them to the event target's `includeKeys`.
+
+`recordEvent` requires `cmcd.eventTargets` to be configured with a target whose `events` array contains the desired event type, and is only meaningful with `version: 2`.
 
 ### `enableInterstitialPlayback`
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -142,6 +142,8 @@ See [API Reference](https://hlsjs-dev.video-dev.org/api-docs/) for a complete li
   - [`drmSystemOptions`](#drmsystemoptions)
   - [`requestMediaKeySystemAccessFunc`](#requestmediakeysystemaccessfunc)
   - [`cmcd`](#cmcd)
+    - [`cmcdCustomData` — runtime getter/setter](#cmcdcustomdata--runtime-gettersetter)
+    - [`cmcdRecordEvent(eventType, data?)` — fire a CMCD event report](#cmcdrecordeventeventtype-data--fire-a-cmcd-event-report)
   - [`enableInterstitialPlayback`](#enableinterstitialplayback)
   - [`interstitialAppendInPlace`](#interstitialappendinplace)
   - [`interstitialLiveLookAhead`](#interstitiallivelookahead)
@@ -1904,6 +1906,54 @@ data will be passed on all media requests (manifests, playlists, a/v segments, t
   - `batchSize`: The number of events to batch before sending a report. Defaults to `1` (send each event immediately).
   - `includeKeys`: An optional array of CMCD keys that overrides the top-level `includeKeys` for this target.
 - `loader`: An optional async function `(request) => Promise<{ status }>` used to deliver CMCD v2 event reports. When omitted, event reports are delivered via `fetch` (honoring the Hls `xhrSetup`/`fetchSetup` hooks). Only used when `eventTargets` is configured.
+- `customData`: An optional set of application-defined key-value pairs to include in every CMCD request report. Accepts either a static object or a callback function:
+  - **Static object** — `Record<string, string | number | boolean | null>`. The values are persisted and included unchanged in every request.
+  - **Callback function** — `() => Record<string, string | number | boolean | null>`. Invoked on every request, so values are resolved at the exact moment of each request. Useful for dynamic state. The function must be synchronous and lightweight — it runs in the hot path of every segment request.
+  - Keys must follow the CMCD custom-key convention: reverse-DNS notation with a hyphen separator, e.g. `com.example-myKey`. See the [SVTA custom keys registry](https://github.com/streaming-video-technology-alliance/common-media-client-data-custom-keys).
+  - Custom keys are valid in both CMCD v1 and v2.
+  - Can be updated at runtime via the `cmcdCustomData` setter on the `Hls` instance.
+
+#### `cmcdCustomData` — runtime getter/setter
+
+```js
+// Read the current value
+const data = hls.cmcdCustomData;
+
+// Set a static object (replaces previous value)
+hls.cmcdCustomData = {
+  'com.mycompany-playerVersion': '3.2.1',
+  'com.mycompany-experimentGroup': 'A',
+};
+
+// Set a callback for dynamic values resolved on every request
+hls.cmcdCustomData = () => ({
+  'com.mycompany-bufferHealth': hls.mainForwardBufferInfo?.len ?? 0,
+  'com.mycompany-adBreakActive': adManager.isInAdBreak(),
+});
+```
+
+#### `cmcdRecordEvent(eventType, data?)` — fire a CMCD event report
+
+Fires a CMCD event report via the configured `CmcdReporter`. Requires `cmcd.eventTargets` to include a target whose `events` array contains the desired event type; otherwise the CML silently drops the event.
+
+```js
+const hls = new Hls({
+  cmcd: {
+    version: 2,
+    eventTargets: [
+      {
+        url: 'https://analytics.example.com/cmcd',
+        events: ['ce'], // 'ce' = CmcdEventType.CUSTOM_EVENT
+        includeKeys: ['sid', 'cid', 'cen'],
+      },
+    ],
+  },
+});
+
+hls.cmcdRecordEvent('ce', { cen: 'chapter-change', 'com.myco-chapterid': '3' });
+```
+
+Custom events are only meaningful with `version: 2`. A warning is logged if called with `version: 1`.
 
 ### `enableInterstitialPlayback`
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -53,6 +53,10 @@ import type {
 
 export type CmcdValue = string | number | boolean | null;
 
+export type CmcdCustomDataInput =
+  | Record<string, CmcdValue>
+  | (() => Record<string, CmcdValue>);
+
 export type ABRControllerConfig = {
   abrEwmaFastLive: number;
   abrEwmaSlowLive: number;

--- a/src/config.ts
+++ b/src/config.ts
@@ -51,6 +51,8 @@ import type {
   CmcdVersion,
 } from '@svta/cml-cmcd';
 
+export type CmcdValue = string | number | boolean | null;
+
 export type ABRControllerConfig = {
   abrEwmaFastLive: number;
   abrEwmaSlowLive: number;
@@ -101,6 +103,7 @@ export type CMCDControllerConfig = {
     headers?: Record<string, string>;
     body?: BodyInit;
   }) => Promise<{ status: number }>;
+  customData?: Record<string, CmcdValue> | (() => Record<string, CmcdValue>);
 };
 
 export type DRMSystemOptions = {

--- a/src/config.ts
+++ b/src/config.ts
@@ -51,12 +51,6 @@ import type {
   CmcdVersion,
 } from '@svta/cml-cmcd';
 
-export type CmcdValue = string | number | boolean | null;
-
-export type CmcdCustomDataInput =
-  | Record<string, CmcdValue>
-  | (() => Record<string, CmcdValue>);
-
 export type ABRControllerConfig = {
   abrEwmaFastLive: number;
   abrEwmaSlowLive: number;
@@ -107,7 +101,6 @@ export type CMCDControllerConfig = {
     headers?: Record<string, string>;
     body?: BodyInit;
   }) => Promise<{ status: number }>;
-  customData?: Record<string, CmcdValue> | (() => Record<string, CmcdValue>);
 };
 
 export type DRMSystemOptions = {

--- a/src/controller/cmcd-controller.ts
+++ b/src/controller/cmcd-controller.ts
@@ -20,6 +20,7 @@ import {
   removeEventListener,
 } from '../utils/event-listener-helper';
 import type {
+  CmcdCustomDataInput,
   CmcdValue,
   FragmentLoaderConstructor,
   HlsConfig,
@@ -47,10 +48,6 @@ import type {
   PlaylistLoaderContext,
 } from '../types/loader';
 import type { Cmcd, CmcdKey } from '@svta/cml-cmcd';
-
-type CmcdCustomDataInput =
-  | Record<string, CmcdValue>
-  | (() => Record<string, CmcdValue>);
 
 /**
  * Controller to deal with Common Media Client Data (CMCD)

--- a/src/controller/cmcd-controller.ts
+++ b/src/controller/cmcd-controller.ts
@@ -104,7 +104,6 @@ export default class CMCDController implements ComponentAPI {
       sf: CmcdStreamingFormat.HLS,
       sta: this.playerState,
     });
-
     this.reporter.start();
   }
 

--- a/src/controller/cmcd-controller.ts
+++ b/src/controller/cmcd-controller.ts
@@ -11,7 +11,6 @@ import {
   CmcdReporter,
   CmcdStreamingFormat,
   CmcdStreamType,
-  isCmcdCustomKey,
   toCmcdValue,
 } from '@svta/cml-cmcd';
 import { Events } from '../events';
@@ -20,8 +19,6 @@ import {
   removeEventListener,
 } from '../utils/event-listener-helper';
 import type {
-  CmcdCustomDataInput,
-  CmcdValue,
   FragmentLoaderConstructor,
   HlsConfig,
   PlaylistLoaderConstructor,
@@ -47,7 +44,7 @@ import type {
   LoaderContext,
   PlaylistLoaderContext,
 } from '../types/loader';
-import type { Cmcd, CmcdKey } from '@svta/cml-cmcd';
+import type { Cmcd } from '@svta/cml-cmcd';
 
 /**
  * Controller to deal with Common Media Client Data (CMCD)
@@ -62,9 +59,6 @@ export default class CMCDController implements ComponentAPI {
   private buffering: boolean = true;
   private playerState?: CmcdPlayerState;
   private reporter?: CmcdReporter;
-  private reporterEnabledKeys: CmcdKey[] = [];
-  private customData: CmcdCustomDataInput | undefined;
-  private activeCustomKeys = new Set<string>();
 
   constructor(hls: Hls) {
     this.hls = hls;
@@ -87,20 +81,15 @@ export default class CMCDController implements ComponentAPI {
 
     const version = cmcd.version || CMCD_V1;
 
-    // Build enabledKeys as a mutable array we keep a reference to.
-    // We add custom keys into it later as they are discovered so that
-    // the CML's per-request filter passes them through.
-    this.reporterEnabledKeys = cmcd.includeKeys
-      ? [...cmcd.includeKeys]
-      : [...(version >= CMCD_V2 ? CMCD_KEYS : CMCD_V1_KEYS)];
-
     this.reporter = new CmcdReporter(
       {
         sid: cmcd.sessionId || this.hls.sessionId,
         cid: cmcd.contentId,
         version,
         transmissionMode: cmcd.useHeaders === true ? CMCD_HEADERS : CMCD_QUERY,
-        enabledKeys: this.reporterEnabledKeys,
+        enabledKeys: cmcd.includeKeys ?? [
+          ...(version >= CMCD_V2 ? CMCD_KEYS : CMCD_V1_KEYS),
+        ],
         eventTargets: (cmcd.eventTargets ?? []).map(
           ({ includeKeys, ...rest }) => ({
             ...rest,
@@ -116,99 +105,15 @@ export default class CMCDController implements ComponentAPI {
       sta: this.playerState,
     });
 
-    if (this.customData === undefined && cmcd.customData) {
-      this.customData = cmcd.customData;
-    }
-    if (this.customData && typeof this.customData !== 'function') {
-      this.pushCustomDataToReporter(this.customData);
-    }
-
     this.reporter.start();
   }
 
-  setCustomData(data: CmcdCustomDataInput): void {
-    this.customData = data;
-    if (this.reporter && typeof data !== 'function') {
-      this.pushCustomDataToReporter(data);
-    }
+  update(data: Cmcd): void {
+    this.reporter?.update(data);
   }
 
-  getCustomData(): CmcdCustomDataInput | undefined {
-    return this.customData;
-  }
-
-  recordEvent(
-    eventType: CmcdEventType | string,
-    data?: Record<string, CmcdValue>,
-  ): void {
-    if (!this.reporter) return;
-    if (this.config.cmcd?.version !== CMCD_V2) {
-      this.hls.logger.warn(
-        'cmcdRecordEvent: custom events are only meaningful in CMCD v2',
-      );
-    }
-    // The library's per-target filter only allows keys listed in enabledKeys.
-    // Custom keys (com.*) passed inline with an event are not known at init
-    // time, so we register them now so they survive the filter.
-    if (data) {
-      const reporterConfig = (this.reporter as any).config;
-      const customKeys = Object.keys(data).filter(isCmcdCustomKey);
-      if (customKeys.length > 0 && reporterConfig?.eventTargets) {
-        reporterConfig.eventTargets.forEach((target: any) => {
-          customKeys.forEach((key) => {
-            if (!target.enabledKeys.includes(key)) {
-              target.enabledKeys.push(key);
-            }
-          });
-        });
-      }
-    }
-    this.reporter.recordEvent(
-      eventType as CmcdEventType,
-      data as Cmcd | undefined,
-    );
-  }
-
-  private resolveCustomData(): Record<string, CmcdValue> {
-    if (!this.customData) return {};
-    if (typeof this.customData === 'function') {
-      return this.customData();
-    }
-    return this.customData;
-  }
-
-  // Updates the reporter with the new custom data, clearing any keys that
-  // are no longer present so they stop appearing in subsequent requests.
-  private pushCustomDataToReporter(data: Record<string, CmcdValue>): void {
-    if (!this.reporter) return;
-    const newKeys = new Set(Object.keys(data));
-
-    // Build a clear object for keys that were active but are no longer present
-    const clearObj: Record<string, undefined> = {};
-    // Use forEach (not for...of or [...set]) to avoid Babel loose-mode
-    // compiling spread to [].concat(set), which wraps the Set as one element.
-    this.activeCustomKeys.forEach((key) => {
-      if (!newKeys.has(key)) {
-        clearObj[key] = undefined;
-      }
-    });
-    if (Object.keys(clearObj).length) {
-      this.reporter.update(clearObj as Cmcd);
-    }
-
-    this.activeCustomKeys = newKeys;
-
-    // Add new custom keys to the shared enabledKeys array so the CML's
-    // per-request filter passes them through.
-    newKeys.forEach((key) => {
-      if (!this.reporterEnabledKeys.includes(key as CmcdKey)) {
-        this.reporterEnabledKeys.push(key as CmcdKey);
-      }
-    });
-
-    if (newKeys.size > 0) {
-      this.reporter.update(data as Cmcd);
-    }
+  recordEvent(eventType: CmcdEventType | string, data?: Cmcd): void {
+    this.reporter?.recordEvent(eventType as CmcdEventType, data);
   }
 
   private registerListeners() {
@@ -357,7 +262,6 @@ export default class CMCDController implements ComponentAPI {
     if (this.reporter) {
       this.reporter.stop(true);
       this.reporter = undefined;
-      this.activeCustomKeys = new Set();
     }
 
     this.createReporter();
@@ -435,15 +339,6 @@ export default class CMCDController implements ComponentAPI {
       pr: this.media?.playbackRate,
       st: this.getStreamType(),
     });
-
-    if (this.customData) {
-      try {
-        const custom = this.resolveCustomData();
-        this.pushCustomDataToReporter(custom);
-      } catch (error) {
-        this.hls.logger.warn('Could not resolve CMCD custom data.', error);
-      }
-    }
 
     const isVideo =
       data.ot === CmcdObjectType.INIT ||

--- a/src/controller/cmcd-controller.ts
+++ b/src/controller/cmcd-controller.ts
@@ -11,6 +11,7 @@ import {
   CmcdReporter,
   CmcdStreamingFormat,
   CmcdStreamType,
+  isCmcdCustomKey,
   toCmcdValue,
 } from '@svta/cml-cmcd';
 import { Events } from '../events';
@@ -19,6 +20,7 @@ import {
   removeEventListener,
 } from '../utils/event-listener-helper';
 import type {
+  CmcdValue,
   FragmentLoaderConstructor,
   HlsConfig,
   PlaylistLoaderConstructor,
@@ -44,7 +46,11 @@ import type {
   LoaderContext,
   PlaylistLoaderContext,
 } from '../types/loader';
-import type { Cmcd } from '@svta/cml-cmcd';
+import type { Cmcd, CmcdKey } from '@svta/cml-cmcd';
+
+type CmcdCustomDataInput =
+  | Record<string, CmcdValue>
+  | (() => Record<string, CmcdValue>);
 
 /**
  * Controller to deal with Common Media Client Data (CMCD)
@@ -59,6 +65,9 @@ export default class CMCDController implements ComponentAPI {
   private buffering: boolean = true;
   private playerState?: CmcdPlayerState;
   private reporter?: CmcdReporter;
+  private reporterEnabledKeys: CmcdKey[] = [];
+  private customData: CmcdCustomDataInput | undefined;
+  private activeCustomKeys = new Set<string>();
 
   constructor(hls: Hls) {
     this.hls = hls;
@@ -81,15 +90,20 @@ export default class CMCDController implements ComponentAPI {
 
     const version = cmcd.version || CMCD_V1;
 
+    // Build enabledKeys as a mutable array we keep a reference to.
+    // We add custom keys into it later as they are discovered so that
+    // the CML's per-request filter passes them through.
+    this.reporterEnabledKeys = cmcd.includeKeys
+      ? [...cmcd.includeKeys]
+      : [...(version >= CMCD_V2 ? CMCD_KEYS : CMCD_V1_KEYS)];
+
     this.reporter = new CmcdReporter(
       {
         sid: cmcd.sessionId || this.hls.sessionId,
         cid: cmcd.contentId,
         version,
         transmissionMode: cmcd.useHeaders === true ? CMCD_HEADERS : CMCD_QUERY,
-        enabledKeys: cmcd.includeKeys ?? [
-          ...(version >= CMCD_V2 ? CMCD_KEYS : CMCD_V1_KEYS),
-        ],
+        enabledKeys: this.reporterEnabledKeys,
         eventTargets: (cmcd.eventTargets ?? []).map(
           ({ includeKeys, ...rest }) => ({
             ...rest,
@@ -104,7 +118,100 @@ export default class CMCDController implements ComponentAPI {
       sf: CmcdStreamingFormat.HLS,
       sta: this.playerState,
     });
+
+    if (this.customData === undefined && cmcd.customData) {
+      this.customData = cmcd.customData;
+    }
+    if (this.customData && typeof this.customData !== 'function') {
+      this.pushCustomDataToReporter(this.customData);
+    }
+
     this.reporter.start();
+  }
+
+  setCustomData(data: CmcdCustomDataInput): void {
+    this.customData = data;
+    if (this.reporter && typeof data !== 'function') {
+      this.pushCustomDataToReporter(data);
+    }
+  }
+
+  getCustomData(): CmcdCustomDataInput | undefined {
+    return this.customData;
+  }
+
+  recordEvent(
+    eventType: CmcdEventType | string,
+    data?: Record<string, CmcdValue>,
+  ): void {
+    if (!this.reporter) return;
+    if (this.config.cmcd?.version !== CMCD_V2) {
+      this.hls.logger.warn(
+        'cmcdRecordEvent: custom events are only meaningful in CMCD v2',
+      );
+    }
+    // The library's per-target filter only allows keys listed in enabledKeys.
+    // Custom keys (com.*) passed inline with an event are not known at init
+    // time, so we register them now so they survive the filter.
+    if (data) {
+      const reporterConfig = (this.reporter as any).config;
+      const customKeys = Object.keys(data).filter(isCmcdCustomKey);
+      if (customKeys.length > 0 && reporterConfig?.eventTargets) {
+        reporterConfig.eventTargets.forEach((target: any) => {
+          customKeys.forEach((key) => {
+            if (!target.enabledKeys.includes(key)) {
+              target.enabledKeys.push(key);
+            }
+          });
+        });
+      }
+    }
+    this.reporter.recordEvent(
+      eventType as CmcdEventType,
+      data as Cmcd | undefined,
+    );
+  }
+
+  private resolveCustomData(): Record<string, CmcdValue> {
+    if (!this.customData) return {};
+    if (typeof this.customData === 'function') {
+      return this.customData();
+    }
+    return this.customData;
+  }
+
+  // Updates the reporter with the new custom data, clearing any keys that
+  // are no longer present so they stop appearing in subsequent requests.
+  private pushCustomDataToReporter(data: Record<string, CmcdValue>): void {
+    if (!this.reporter) return;
+    const newKeys = new Set(Object.keys(data));
+
+    // Build a clear object for keys that were active but are no longer present
+    const clearObj: Record<string, undefined> = {};
+    // Use forEach (not for...of or [...set]) to avoid Babel loose-mode
+    // compiling spread to [].concat(set), which wraps the Set as one element.
+    this.activeCustomKeys.forEach((key) => {
+      if (!newKeys.has(key)) {
+        clearObj[key] = undefined;
+      }
+    });
+    if (Object.keys(clearObj).length) {
+      this.reporter.update(clearObj as Cmcd);
+    }
+
+    this.activeCustomKeys = newKeys;
+
+    // Add new custom keys to the shared enabledKeys array so the CML's
+    // per-request filter passes them through.
+    newKeys.forEach((key) => {
+      if (!this.reporterEnabledKeys.includes(key as CmcdKey)) {
+        this.reporterEnabledKeys.push(key as CmcdKey);
+      }
+    });
+
+    if (newKeys.size > 0) {
+      this.reporter.update(data as Cmcd);
+    }
   }
 
   private registerListeners() {
@@ -253,6 +360,7 @@ export default class CMCDController implements ComponentAPI {
     if (this.reporter) {
       this.reporter.stop(true);
       this.reporter = undefined;
+      this.activeCustomKeys = new Set();
     }
 
     this.createReporter();
@@ -266,7 +374,7 @@ export default class CMCDController implements ComponentAPI {
     if (data.fatal) {
       this.setPlayerState(CmcdPlayerState.FATAL_ERROR);
       if (this.reporter) {
-        this.reporter.recordEvent(CmcdEventType.ERROR);
+        this.reporter.recordEvent(CmcdEventType.ERROR, { ec: [data.details] });
       }
     }
   }
@@ -330,6 +438,15 @@ export default class CMCDController implements ComponentAPI {
       pr: this.media?.playbackRate,
       st: this.getStreamType(),
     });
+
+    if (this.customData) {
+      try {
+        const custom = this.resolveCustomData();
+        this.pushCustomDataToReporter(custom);
+      } catch (error) {
+        this.hls.logger.warn('Could not resolve CMCD custom data.', error);
+      }
+    }
 
     const isVideo =
       data.ot === CmcdObjectType.INIT ||

--- a/src/hls.ts
+++ b/src/hls.ts
@@ -17,7 +17,7 @@ import { getMediaDecodingInfoPromise } from './utils/mediacapabilities-helper';
 import { getMediaSource } from './utils/mediasource-helper';
 import { getAudioTracksByGroup } from './utils/rendition-helper';
 import { version } from './version';
-import type { CmcdValue, HlsConfig } from './config';
+import type { HlsConfig } from './config';
 import type AbrController from './controller/abr-controller';
 import type AudioStreamController from './controller/audio-stream-controller';
 import type AudioTrackController from './controller/audio-track-controller';
@@ -114,7 +114,7 @@ export default class Hls implements HlsEventEmitter {
   private iframeController?: IFrameController;
   private gapController?: GapController;
   private emeController?: EMEController;
-  private cmcdController?: CMCDController;
+  public cmcdController?: CMCDController;
   private _media: HTMLMediaElement | null = null;
   private _sessionId?: string;
   private triggeringException?: boolean;
@@ -453,37 +453,6 @@ export default class Hls implements HlsEventEmitter {
 
   listenerCount<E extends keyof HlsListeners>(event: E): number {
     return this._emitter.listenerCount(event);
-  }
-
-  /**
-   * Get or set custom CMCD data to include in every request report.
-   * Accepts a static object or a callback function invoked on each request.
-   * Keys must follow the reverse-DNS convention (e.g. `com.example-myKey`).
-   */
-  get cmcdCustomData():
-    | Record<string, CmcdValue>
-    | (() => Record<string, CmcdValue>)
-    | undefined {
-    return this.cmcdController?.getCustomData();
-  }
-
-  set cmcdCustomData(
-    data: Record<string, CmcdValue> | (() => Record<string, CmcdValue>),
-  ) {
-    this.cmcdController?.setCustomData(data);
-  }
-
-  /**
-   * Fire a CMCD event report via the CmcdReporter.
-   * Requires `cmcd.eventTargets` to be configured with the target event type.
-   * Only meaningful when `cmcd.version` is 2.
-   */
-  cmcdRecordEvent(eventType: string, data?: Record<string, CmcdValue>): void {
-    if (!this.cmcdController) {
-      this.logger.warn('cmcdRecordEvent called but CMCD is not configured');
-      return;
-    }
-    this.cmcdController.recordEvent(eventType, data);
   }
 
   /**
@@ -1393,7 +1362,6 @@ export type {
   SubtitleSelectionOption,
   VideoSelectionOption,
   MediaPlaylist,
-  CmcdValue,
   ErrorDetails,
   ErrorTypes,
   Events,
@@ -1443,7 +1411,6 @@ export type {
 };
 export type {
   ABRControllerConfig,
-  CmcdCustomDataInput,
   PlaylistControllerConfig,
   BufferControllerConfig,
   CapLevelControllerConfig,

--- a/src/hls.ts
+++ b/src/hls.ts
@@ -17,7 +17,7 @@ import { getMediaDecodingInfoPromise } from './utils/mediacapabilities-helper';
 import { getMediaSource } from './utils/mediasource-helper';
 import { getAudioTracksByGroup } from './utils/rendition-helper';
 import { version } from './version';
-import type { HlsConfig } from './config';
+import type { CmcdValue, HlsConfig } from './config';
 import type AbrController from './controller/abr-controller';
 import type AudioStreamController from './controller/audio-stream-controller';
 import type AudioTrackController from './controller/audio-track-controller';
@@ -453,6 +453,37 @@ export default class Hls implements HlsEventEmitter {
 
   listenerCount<E extends keyof HlsListeners>(event: E): number {
     return this._emitter.listenerCount(event);
+  }
+
+  /**
+   * Get or set custom CMCD data to include in every request report.
+   * Accepts a static object or a callback function invoked on each request.
+   * Keys must follow the reverse-DNS convention (e.g. `com.example-myKey`).
+   */
+  get cmcdCustomData():
+    | Record<string, CmcdValue>
+    | (() => Record<string, CmcdValue>)
+    | undefined {
+    return this.cmcdController?.getCustomData();
+  }
+
+  set cmcdCustomData(
+    data: Record<string, CmcdValue> | (() => Record<string, CmcdValue>),
+  ) {
+    this.cmcdController?.setCustomData(data);
+  }
+
+  /**
+   * Fire a CMCD event report via the CmcdReporter.
+   * Requires `cmcd.eventTargets` to be configured with the target event type.
+   * Only meaningful when `cmcd.version` is 2.
+   */
+  cmcdRecordEvent(eventType: string, data?: Record<string, CmcdValue>): void {
+    if (!this.cmcdController) {
+      this.logger.warn('cmcdRecordEvent called but CMCD is not configured');
+      return;
+    }
+    this.cmcdController.recordEvent(eventType, data);
   }
 
   /**

--- a/src/hls.ts
+++ b/src/hls.ts
@@ -1393,6 +1393,7 @@ export type {
   SubtitleSelectionOption,
   VideoSelectionOption,
   MediaPlaylist,
+  CmcdValue,
   ErrorDetails,
   ErrorTypes,
   Events,
@@ -1442,6 +1443,7 @@ export type {
 };
 export type {
   ABRControllerConfig,
+  CmcdCustomDataInput,
   PlaylistControllerConfig,
   BufferControllerConfig,
   CapLevelControllerConfig,

--- a/tests/unit/controller/cmcd-controller.ts
+++ b/tests/unit/controller/cmcd-controller.ts
@@ -1180,108 +1180,12 @@ describe('CMCDController', function () {
     });
   });
 
-  describe('custom data and events', function () {
-    it('includes static customData from config in request URLs', function () {
-      setupEach({
-        customData: { 'com.test-mykey': 'hello' },
-      });
+  describe('update and recordEvent', function () {
+    it('update applies custom keys to subsequent request URLs when includeKeys is configured', function () {
+      setupEach({ includeKeys: ['sid', 'sf', 'com.test-mykey'] as any });
+      cmcdController.update({ 'com.test-mykey': 'hello' } as any);
       const { url: result } = applyPlaylistData();
       expectField(result, 'com.test-mykey');
-    });
-
-    it('does not include static customData keys in URL when not set', function () {
-      setupEach({});
-      const { url: result } = applyPlaylistData();
-      expect(result).to.not.include('com.test-mykey');
-    });
-
-    it('invokes customData function on each request, not at reporter init', function () {
-      let callCount = 0;
-      setupEach({
-        customData: () => {
-          callCount++;
-          return { 'com.test-count': callCount };
-        },
-      });
-      // Function should NOT have been called during reporter init
-      expect(callCount).to.equal(0);
-
-      applyPlaylistData();
-      expect(callCount).to.equal(1);
-
-      applyPlaylistData();
-      expect(callCount).to.equal(2);
-    });
-
-    it('includes customData function result in request URL', function () {
-      setupEach({
-        customData: () => ({ 'com.test-dyn': 'value' }),
-      });
-      const { url: result } = applyPlaylistData();
-      expectField(result, 'com.test-dyn');
-    });
-
-    it('setCustomData with static object updates reporter immediately and appears in next request', function () {
-      setupEach({});
-      cmcdController.setCustomData({ 'com.test-runtime': 'set' });
-      const { url: result } = applyPlaylistData();
-      expectField(result, 'com.test-runtime');
-    });
-
-    it('setCustomData with function does not update reporter immediately, but invokes on next request', function () {
-      setupEach({});
-      let callCount = 0;
-      cmcdController.setCustomData(() => {
-        callCount++;
-        return { 'com.test-fn': callCount };
-      });
-      // setCustomData should not have called the function
-      expect(callCount).to.equal(0);
-
-      applyPlaylistData();
-      expect(callCount).to.equal(1);
-      const { url: result } = applyPlaylistData();
-      expect(callCount).to.equal(2);
-      expectField(result, 'com.test-fn');
-    });
-
-    it('getCustomData returns the last value set via setCustomData', function () {
-      setupEach({});
-      const data = { 'com.test-get': 42 };
-      cmcdController.setCustomData(data);
-      expect(cmcdController.getCustomData()).to.equal(data);
-    });
-
-    it('customData persists through MANIFEST_LOADING (reporter recreated)', function () {
-      setupEach({ customData: { 'com.test-persist': 'yes' } });
-      // Trigger a second manifest load to recreate the reporter
-      cmcdController.hls.trigger(Events.MANIFEST_LOADING, { url });
-      const { url: result } = applyPlaylistData();
-      expectField(result, 'com.test-persist');
-    });
-
-    it('clearing customData with empty object removes previously-set keys from subsequent requests', function () {
-      setupEach({ customData: { 'com.test-mykey': 'hello' } });
-      // Key is present before clearing
-      expectField(applyPlaylistData().url, 'com.test-mykey');
-
-      // Clear via empty object (mirrors hls.cmcdCustomData = {} in the demo)
-      cmcdController.setCustomData({});
-      const { url: afterClear } = applyPlaylistData();
-      expect(afterClear).to.not.include('com.test-mykey');
-      // Standard CMCD keys are unaffected by clearing custom data
-      expectField(afterClear, 'sf%3Dh');
-      expectField(afterClear, 'sid%3D');
-    });
-
-    it('swallows errors thrown by customData function and continues the request', function () {
-      setupEach({
-        customData: () => {
-          throw new Error('bad callback');
-        },
-      });
-      // Should not throw; URL should still be modified (without custom data)
-      expect(() => applyPlaylistData()).to.not.throw();
     });
 
     it('recordEvent delegates to reporter.recordEvent and emits a POST to the event target', function () {
@@ -1303,7 +1207,7 @@ describe('CMCDController', function () {
 
       cmcdController.recordEvent(CmcdEventType.CUSTOM_EVENT, {
         cen: 'test-event',
-      });
+      } as any);
 
       const eventRequests = requests.filter(
         (r) => r.url === 'https://analytics.example.com/cmcd',
@@ -1311,7 +1215,7 @@ describe('CMCDController', function () {
       expect(eventRequests.length).to.be.greaterThan(0);
     });
 
-    it('recordEvent includes custom keys alongside cen in the event payload', function () {
+    it('recordEvent includes custom keys when the event target includeKeys lists them', function () {
       const requests: any[] = [];
       const captureLoader = (req: any) => {
         requests.push(req);
@@ -1324,6 +1228,7 @@ describe('CMCDController', function () {
           {
             url: 'https://analytics.example.com/cmcd',
             events: [CmcdEventType.CUSTOM_EVENT],
+            includeKeys: ['cen', 'com.myco-chapterid'] as any,
           },
         ],
       });
@@ -1331,7 +1236,7 @@ describe('CMCDController', function () {
       cmcdController.recordEvent(CmcdEventType.CUSTOM_EVENT, {
         cen: 'chapter-change',
         'com.myco-chapterid': '3',
-      });
+      } as any);
 
       const eventRequests = requests.filter(
         (r) => r.url === 'https://analytics.example.com/cmcd',
@@ -1340,17 +1245,6 @@ describe('CMCDController', function () {
       const body = String(eventRequests[0].body || '');
       expect(body).to.include('cen="chapter-change"');
       expect(body).to.include('com.myco-chapterid="3"');
-    });
-
-    it('recordEvent warns when CMCD version is not v2', function () {
-      const warnings: string[] = [];
-      setupEach({ version: 1 });
-      cmcdController.hls.logger = {
-        ...cmcdController.hls.logger,
-        warn: (msg: string) => warnings.push(msg),
-      };
-      cmcdController.recordEvent(CmcdEventType.CUSTOM_EVENT);
-      expect(warnings.some((w) => w.includes('CMCD v2'))).to.equal(true);
     });
 
     it('recordEvent does nothing when reporter is not initialized', function () {
@@ -1363,7 +1257,7 @@ describe('CMCDController', function () {
       const controller = new CMCDController(hls);
       // reporter is not yet created (no MANIFEST_LOADING fired)
       expect(() =>
-        (controller as any).recordEvent(CmcdEventType.CUSTOM_EVENT),
+        controller.recordEvent(CmcdEventType.CUSTOM_EVENT),
       ).to.not.throw();
       controller.destroy();
     });

--- a/tests/unit/controller/cmcd-controller.ts
+++ b/tests/unit/controller/cmcd-controller.ts
@@ -542,9 +542,20 @@ describe('CMCDController', function () {
       });
 
       it('records error events on fatal errors', function () {
+        const requests: any[] = [];
+        const captureLoader = (req: any) => {
+          requests.push(req);
+          return Promise.resolve({ status: 204 });
+        };
         setupEach({
           version: 2,
-          eventTargets: [{ url: 'https://analytics.example.com/cmcd' }],
+          loader: captureLoader as any,
+          eventTargets: [
+            {
+              url: 'https://analytics.example.com/cmcd',
+              events: [CmcdEventType.ERROR],
+            },
+          ],
         });
 
         // Trigger fatal error via hls event
@@ -557,6 +568,15 @@ describe('CMCDController', function () {
 
         // Player state should transition to FATAL_ERROR
         expect((cmcdController as any).playerState).to.equal('f');
+
+        const eventRequests = requests.filter(
+          (r) => r.url === 'https://analytics.example.com/cmcd',
+        );
+        const body = String(eventRequests[0].body || '');
+        expect(eventRequests.length).to.be.greaterThan(0);
+        expect(body).to.include('e=e');
+        expect(body).to.include('ec=("fragLoadError")');
+        expect(body).to.include('ts=');
 
         cmcdController.destroy();
       });
@@ -1157,6 +1177,195 @@ describe('CMCDController', function () {
         );
         expect(result).to.equal(2000000);
       });
+    });
+  });
+
+  describe('custom data and events', function () {
+    it('includes static customData from config in request URLs', function () {
+      setupEach({
+        customData: { 'com.test-mykey': 'hello' },
+      });
+      const { url: result } = applyPlaylistData();
+      expectField(result, 'com.test-mykey');
+    });
+
+    it('does not include static customData keys in URL when not set', function () {
+      setupEach({});
+      const { url: result } = applyPlaylistData();
+      expect(result).to.not.include('com.test-mykey');
+    });
+
+    it('invokes customData function on each request, not at reporter init', function () {
+      let callCount = 0;
+      setupEach({
+        customData: () => {
+          callCount++;
+          return { 'com.test-count': callCount };
+        },
+      });
+      // Function should NOT have been called during reporter init
+      expect(callCount).to.equal(0);
+
+      applyPlaylistData();
+      expect(callCount).to.equal(1);
+
+      applyPlaylistData();
+      expect(callCount).to.equal(2);
+    });
+
+    it('includes customData function result in request URL', function () {
+      setupEach({
+        customData: () => ({ 'com.test-dyn': 'value' }),
+      });
+      const { url: result } = applyPlaylistData();
+      expectField(result, 'com.test-dyn');
+    });
+
+    it('setCustomData with static object updates reporter immediately and appears in next request', function () {
+      setupEach({});
+      cmcdController.setCustomData({ 'com.test-runtime': 'set' });
+      const { url: result } = applyPlaylistData();
+      expectField(result, 'com.test-runtime');
+    });
+
+    it('setCustomData with function does not update reporter immediately, but invokes on next request', function () {
+      setupEach({});
+      let callCount = 0;
+      cmcdController.setCustomData(() => {
+        callCount++;
+        return { 'com.test-fn': callCount };
+      });
+      // setCustomData should not have called the function
+      expect(callCount).to.equal(0);
+
+      applyPlaylistData();
+      expect(callCount).to.equal(1);
+      const { url: result } = applyPlaylistData();
+      expect(callCount).to.equal(2);
+      expectField(result, 'com.test-fn');
+    });
+
+    it('getCustomData returns the last value set via setCustomData', function () {
+      setupEach({});
+      const data = { 'com.test-get': 42 };
+      cmcdController.setCustomData(data);
+      expect(cmcdController.getCustomData()).to.equal(data);
+    });
+
+    it('customData persists through MANIFEST_LOADING (reporter recreated)', function () {
+      setupEach({ customData: { 'com.test-persist': 'yes' } });
+      // Trigger a second manifest load to recreate the reporter
+      cmcdController.hls.trigger(Events.MANIFEST_LOADING, { url });
+      const { url: result } = applyPlaylistData();
+      expectField(result, 'com.test-persist');
+    });
+
+    it('clearing customData with empty object removes previously-set keys from subsequent requests', function () {
+      setupEach({ customData: { 'com.test-mykey': 'hello' } });
+      // Key is present before clearing
+      expectField(applyPlaylistData().url, 'com.test-mykey');
+
+      // Clear via empty object (mirrors hls.cmcdCustomData = {} in the demo)
+      cmcdController.setCustomData({});
+      const { url: afterClear } = applyPlaylistData();
+      expect(afterClear).to.not.include('com.test-mykey');
+      // Standard CMCD keys are unaffected by clearing custom data
+      expectField(afterClear, 'sf%3Dh');
+      expectField(afterClear, 'sid%3D');
+    });
+
+    it('swallows errors thrown by customData function and continues the request', function () {
+      setupEach({
+        customData: () => {
+          throw new Error('bad callback');
+        },
+      });
+      // Should not throw; URL should still be modified (without custom data)
+      expect(() => applyPlaylistData()).to.not.throw();
+    });
+
+    it('recordEvent delegates to reporter.recordEvent and emits a POST to the event target', function () {
+      const requests: any[] = [];
+      const captureLoader = (req: any) => {
+        requests.push(req);
+        return Promise.resolve({ status: 204 });
+      };
+      setupEach({
+        version: 2,
+        loader: captureLoader as any,
+        eventTargets: [
+          {
+            url: 'https://analytics.example.com/cmcd',
+            events: [CmcdEventType.CUSTOM_EVENT],
+          },
+        ],
+      });
+
+      cmcdController.recordEvent(CmcdEventType.CUSTOM_EVENT, {
+        cen: 'test-event',
+      });
+
+      const eventRequests = requests.filter(
+        (r) => r.url === 'https://analytics.example.com/cmcd',
+      );
+      expect(eventRequests.length).to.be.greaterThan(0);
+    });
+
+    it('recordEvent includes custom keys alongside cen in the event payload', function () {
+      const requests: any[] = [];
+      const captureLoader = (req: any) => {
+        requests.push(req);
+        return Promise.resolve({ status: 204 });
+      };
+      setupEach({
+        version: 2,
+        loader: captureLoader as any,
+        eventTargets: [
+          {
+            url: 'https://analytics.example.com/cmcd',
+            events: [CmcdEventType.CUSTOM_EVENT],
+          },
+        ],
+      });
+
+      cmcdController.recordEvent(CmcdEventType.CUSTOM_EVENT, {
+        cen: 'chapter-change',
+        'com.myco-chapterid': '3',
+      });
+
+      const eventRequests = requests.filter(
+        (r) => r.url === 'https://analytics.example.com/cmcd',
+      );
+      expect(eventRequests.length).to.be.greaterThan(0);
+      const body = String(eventRequests[0].body || '');
+      expect(body).to.include('cen="chapter-change"');
+      expect(body).to.include('com.myco-chapterid="3"');
+    });
+
+    it('recordEvent warns when CMCD version is not v2', function () {
+      const warnings: string[] = [];
+      setupEach({ version: 1 });
+      cmcdController.hls.logger = {
+        ...cmcdController.hls.logger,
+        warn: (msg: string) => warnings.push(msg),
+      };
+      cmcdController.recordEvent(CmcdEventType.CUSTOM_EVENT);
+      expect(warnings.some((w) => w.includes('CMCD v2'))).to.equal(true);
+    });
+
+    it('recordEvent does nothing when reporter is not initialized', function () {
+      const hls = new Hls({ cmcd: { version: 2 } }) as any;
+      hls.networkControllers.forEach((c) => c.destroy());
+      hls.networkControllers.length = 0;
+      hls.coreComponents.forEach((c) => c.destroy());
+      hls.coreComponents.length = 0;
+
+      const controller = new CMCDController(hls);
+      // reporter is not yet created (no MANIFEST_LOADING fired)
+      expect(() =>
+        (controller as any).recordEvent(CmcdEventType.CUSTOM_EVENT),
+      ).to.not.throw();
+      controller.destroy();
     });
   });
 });


### PR DESCRIPTION
This PR adds a runtime API for CMCD v2 by exposing two public methods directly on CMCDController and making hls.cmcdController a public property.

- Adds `CMCDController.update(data: Cmcd)` — thin wrapper over CmcdReporter.update(), allowing callers to inject or update persistent CMCD fields (including custom keys) at any point during playback.
- Adds `CMCDController.recordEvent(eventType, data?)` — thin wrapper over CmcdReporter.recordEvent(), allowing callers to fire CMCD v2 event reports programmatically.
- Makes hls.cmcdController a public property so the controller is reachable without adding methods to the Hls class (CMCD is optional and should not inflate the top-level player API surface).
- Passes `{ ec: [data.details] }` when recording fatal error events, so the error code is included in the event payload.

### Usage
```
const hls = new Hls({
  cmcd: {
    version: 2,
    includeKeys: ['sid', 'sf', 'com.myco-session'],
    eventTargets: [
      {
        url: 'https://analytics.example.com/cmcd',
        events: ['ce'],
        includeKeys: ['cen', 'com.myco-chapterid'],
      },
    ],
  },
});

// Set persistent custom data on all subsequent request reports
hls.cmcdController?.update({
  'com.myco-session': sessionManager.getId(),
});

// Fire a custom event report
hls.cmcdController?.recordEvent('ce', {
  cen: 'chapter-change',
  'com.myco-chapterid': '3',
});

```

### Resolves issues:

[Open issue](https://github.com/video-dev/hls.js/issues/7886)

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [x] API or design changes are documented in API.md
